### PR TITLE
3 phase changes

### DIFF
--- a/custom_components/beny_wifi/communication.py
+++ b/custom_components/beny_wifi/communication.py
@@ -105,6 +105,44 @@ def read_message(data, msg_type:str | None = None) -> dict:  # noqa: C901
                 _LOGGER.error(f"Invalid value for {param}: value")  # noqa: G004
                 msg[param] = None
 
+    if msg_type == SERVER_MESSAGE.SEND_DLB_3P:
+        # 3-phase DLB packet (msg_len=0x21, 33 bytes, msg_int=33).
+        # Each power field has three 16-bit per-phase values; totals are the sum of all phases.
+        # Grid phases are signed 16-bit two's complement (negative = exporting to grid).
+        # If any phase of solar/ev/house hits the 0xFF00+ sentinel, the whole field becomes None
+        # so the coordinator retains the last valid reading rather than producing a bogus total.
+        # Reverse-engineered from BCP-AT1N-L capture vs Z-Box ground truth (÷100 gives kW totals).
+        _FIELD_MAP_3P = {
+            "solar_phase1": "solar_power", "solar_phase2": "solar_power", "solar_phase3": "solar_power",
+            "ev_phase1":    "ev_power",    "ev_phase2":    "ev_power",    "ev_phase3":    "ev_power",
+            "house_phase1": "house_power", "house_phase2": "house_power", "house_phase3": "house_power",
+            "grid_phase1":  "grid_power",  "grid_phase2":  "grid_power",  "grid_phase3":  "grid_power",
+        }
+        phase_sums: dict = {"solar_power": 0.0, "ev_power": 0.0, "house_power": 0.0, "grid_power": 0.0}
+        sentinel_fields: set = set()
+
+        for param, pos in msg_type.value["structure"].items():
+            value = int(data[pos], 16)
+            target = _FIELD_MAP_3P[param]
+            if target == "grid_power":
+                # All three grid phases are signed 16-bit two's complement
+                if value >= 0x8000:
+                    value = value - 0x10000
+                phase_sums[target] += float(value) / _DLB_POWER_DIVISOR
+            else:
+                # Solar, EV, house: unsigned. A sentinel on any single phase
+                # marks the whole field unavailable for this cycle.
+                if value >= _DLB_SENTINEL_THRESHOLD:
+                    _LOGGER.debug(  # noqa: G004
+                        f"3P DLB sentinel on {param}: {value:#06x} — marking {target} as unavailable"
+                    )
+                    sentinel_fields.add(target)
+                elif target not in sentinel_fields:
+                    phase_sums[target] += float(value) / _DLB_POWER_DIVISOR
+
+        for field, total in phase_sums.items():
+            msg[field] = None if field in sentinel_fields else round(total, 2)
+
     # charger ACKs SET_DLB_CONFIG or responds to GET_DLB_CONFIG with current config state
     if msg_type == SERVER_MESSAGE.SEND_DLB_CONFIG:
         for param, pos in msg_type.value["structure"].items():

--- a/custom_components/beny_wifi/const.py
+++ b/custom_components/beny_wifi/const.py
@@ -452,13 +452,42 @@ class SERVER_MESSAGE(Enum):
         }
     }
     SEND_DLB = {
-        "description": "Receive dlb values",
+        "description": "Receive DLB power values from 1-phase charger (msg_len=0x11, 17 bytes). "
+                       "Packet is fully mapped: 8B header + 8B data (4×16-bit fields) + 1B checksum. "
+                       "solar/ev/house are unsigned 16-bit ÷100 = kW; grid is signed 16-bit two's "
+                       "complement ÷100 = kW (negative = exporting). "
+                       "Detected by msg_id=0x0011 (msg_int=17) with message_type=7b. "
+                       "Verified against live 1P hardware capture with Z-Box ground truth.",
         "structure": {
             "request_type": slice(10, 12),
             "solar_power": slice(16, 20),
             "ev_power": slice(20, 24),
             "house_power": slice(24, 28),
             "grid_power": slice(28, 32)
+        }
+    }
+    SEND_DLB_3P = {
+        "description": "Receive DLB power values from 3-phase charger (msg_len=0x21, 33 bytes). "
+                       "Each of the four power fields is split into three 16-bit per-phase values "
+                       "(÷100 = kW per phase); sensor totals are the sum of all three phases. "
+                       "Grid phases are signed 16-bit two's complement (negative = exporting). "
+                       "Detected by msg_id=0x0021 (msg_int=33) with message_type=7b. "
+                       "Reverse-engineered from BCP-AT1N-L capture vs Z-Box ground truth: "
+                       "Solar=3.31 kW, House=0.46 kW, Grid=−2.85 kW, EV=0.00 kW. "
+                       "Confirmed: sum of per-phase raws ÷100 matches Z-Box totals to within 0.05 kW.",
+        "structure": {
+            "solar_phase1": slice(16, 20),
+            "solar_phase2": slice(20, 24),
+            "solar_phase3": slice(24, 28),
+            "ev_phase1":    slice(28, 32),
+            "ev_phase2":    slice(32, 36),
+            "ev_phase3":    slice(36, 40),
+            "house_phase1": slice(40, 44),
+            "house_phase2": slice(44, 48),
+            "house_phase3": slice(48, 52),
+            "grid_phase1":  slice(52, 56),
+            "grid_phase2":  slice(56, 60),
+            "grid_phase3":  slice(60, 64),
         }
     }
     ACCESS_DENIED = {

--- a/custom_components/beny_wifi/conversions.py
+++ b/custom_components/beny_wifi/conversions.py
@@ -158,8 +158,13 @@ def get_message_type(data: str) -> CLIENT_MESSAGE | SERVER_MESSAGE:
     # Additional status message type 36 added
     if msg_int == 35 or msg_int == 36:
         return SERVER_MESSAGE.SEND_VALUES_3P
-    if msg_int == 33:
-        return SERVER_MESSAGE.SEND_DLB
+    # SEND_DLB detection: both variants share message_type=7b.
+    # The msg_id field encodes the msg_len byte, so the packet size is directly readable:
+    #   1P SEND_DLB:   msg_int=17  (0x0011 → msg_len=0x11=17 bytes)
+    #   3P SEND_DLB:   msg_int=33  (0x0021 → msg_len=0x21=33 bytes, per-phase fields)
+    # Confirmed from BCP-AT1N-L capture vs Z-Box ground truth.
+    if msg_int == 33 and message_type.upper() == '7B':
+        return SERVER_MESSAGE.SEND_DLB_3P
     if msg_int == 17:
         if message_type.upper() == '7B':
             return SERVER_MESSAGE.SEND_DLB

--- a/custom_components/beny_wifi/manifest.json
+++ b/custom_components/beny_wifi/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/Jarauvi/beny_wifi/issues",
   "loggers": ["custom_components.beny_wifi"],
   "requirements": [],
-  "version": "0.8.6"
+  "version": "0.8.7"
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Fix DLB power sensors for 3-phase chargers</h1>
<h2>Description</h2>
<p>This PR reverse-engineers and implements the <strong>3-phase variant of the <code>SEND_DLB</code> packet</strong>, fixing completely incorrect DLB power sensor readings on 3-phase chargers (e.g. BCP-AT1N-L). Previously the integration applied the 1-phase byte mapping to the larger 3-phase packet, reading per-phase solar values as EV and house power, and grid as near-zero because it landed on the idle EV field.</p>
<p>The 3-phase packet structure was confirmed via PCAPdroid capture on a BCP-AT1N-L with simultaneous Z-Box app readings as ground truth. The summed per-phase totals match Z-Box values to within 0.05 kW across all four fields.</p>
<hr>
<h2>Changes Made</h2>
<h3>Protocol Discovery</h3>
<ul>
<li>
<p><strong>Reverse-engineered the 3-phase <code>SEND_DLB</code> packet structure</strong> — The 3-phase charger sends a 33-byte response (<code>msg_len=0x21</code>) versus the 1-phase charger's 17-byte response (<code>msg_len=0x11</code>). The extra 16 bytes are exactly 8 additional 16-bit fields: each of the four power values (solar, EV, house, grid) is split into three per-phase readings rather than a single total. Sensor totals are the sum of all three phases. Confirmed from BCP-AT1N-L hardware capture vs Z-Box ground truth:</p>

Field | Phase 1 | Phase 2 | Phase 3 | Sum ÷100 | Z-Box
-- | -- | -- | -- | -- | --
solar_power | 0x006f | 0x0070 | 0x006f | 3.34 kW | 3.31 kW ✅
ev_power | 0x0000 | 0x0000 | 0x0000 | 0.00 kW | 0.00 kW ✅
house_power | 0x0002 | 0x0004 | 0x002a | 0.48 kW | 0.46 kW ✅
grid_power | 0xff93 | 0xff94 | 0xffbb | −2.86 kW | −2.85 kW ✅


</li>
</ul>
<h3>New Message Definition</h3>
<ul>
<li><strong><code>SEND_DLB_3P</code></strong> added to <code>SERVER_MESSAGE</code> in <code>const.py</code> — defines all 12 per-phase slice positions (<code>solar_phase1–3</code>, <code>ev_phase1–3</code>, <code>house_phase1–3</code>, <code>grid_phase1–3</code>) with full documentation of the confirmed byte layout and hardware evidence.</li>
</ul>
<h3>Routing Fix</h3>
<ul>
<li><strong><code>get_message_type()</code> in <code>conversions.py</code></strong> — <code>msg_int == 33</code> with <code>message_type == '7B'</code> now routes to <code>SERVER_MESSAGE.SEND_DLB_3P</code>. Previously this path fell into the generic <code>SEND_DLB</code> branch. The 1-phase path (<code>msg_int == 17</code>) is unchanged.</li>
</ul>
<h3>Decode Logic</h3>
<ul>
<li><strong><code>read_message()</code> in <code>communication.py</code></strong> — new <code>SEND_DLB_3P</code> decode block sums the three phases for each field to produce the <code>solar_power</code>, <code>ev_power</code>, <code>house_power</code>, and <code>grid_power</code> keys the coordinator and sensor entities already expect — no changes required in <code>coordinator.py</code> or <code>sensor.py</code>.
<ul>
<li>Grid phases decoded as signed 16-bit two's complement (negative = exporting to grid), matching the existing 1-phase handling.</li>
<li>Sentinel logic (<code>0xFF00+</code>) applied per-phase on solar/EV/house: if any single phase returns a sentinel value the entire field is set to <code>None</code> for that cycle, allowing the coordinator to retain the last valid reading rather than producing a corrupt total.</li>
</ul>
</li>
</ul>
<hr>
<h2>Implementation Notes</h2>
<ul>
<li>No changes to <code>coordinator.py</code>, <code>sensor.py</code>, or any entity files — the fix is entirely in the protocol layer. The coordinator's existing sentinel-handling logic (skip <code>None</code> values, retain last valid) works correctly for 3-phase totals without modification.</li>
<li>1-phase behaviour is completely unaffected. The <code>SEND_DLB</code> path in both <code>conversions.py</code> and <code>communication.py</code> is unchanged.</li>
<li>The <code>SEND_DLB_3P</code> sentinel check is conservative: a sentinel on any one phase of a given field (e.g. <code>solar_phase2 = 0xFF10</code>) marks that whole field <code>None</code> rather than attempting a partial sum. This matches the 1-phase policy and avoids underreporting during DLB module state transitions.</li>
</ul>
<hr>
<h2>Testing</h2>
<ul>
<li><strong>Hardware</strong>: Beny Charger BCP-AT1N-L (3-phase, firmware 1.27) with Solar DLB module</li>
<li><strong>Protocol verification</strong>: PCAPdroid UDP capture on port 3333, decoded byte-for-byte against Z-Box app readings. Two consecutive packets verified; both match ground truth to within 0.05 kW on all four fields.</li>
<li><strong>1-phase regression</strong>: 1-phase <code>SEND_DLB</code> routing and decode verified unchanged against the original DLB.txt capture (solar=3.05 kW, house=1.95 kW, grid=−1.10 kW, EV=0.00 kW — all exact matches).</li>
</ul>
<hr>
<h2>Breaking Changes</h2>
<p>None. 1-phase chargers are entirely unaffected. 3-phase charger users will see their DLB sensors change from incorrect values to correct ones — this is the intended fix.</p>
<hr>
<h2>Checklist</h2>
<ul>
<li>[x] 3-phase packet structure reverse-engineered and verified against hardware capture</li>
<li>[x] Per-phase sums confirmed to match Z-Box ground truth to within 0.05 kW on all four fields</li>
<li>[x] 1-phase <code>SEND_DLB</code> routing and decode verified unchanged</li>
<li>[x] Sentinel (<code>0xFF00+</code>) handling verified: sentinel on any phase correctly produces <code>None</code> total</li>
<li>[x] No changes required outside the protocol layer (<code>const.py</code>, <code>conversions.py</code>, <code>communication.py</code>)</li>
<li>[x] All modified files pass Python syntax check</li>
<li>[x] Version bumped to 0.8.7</li>
</ul></body></html><!--EndFragment-->
</body>
</html>