### PR TITLE
Bug fix for Extreme mode toggle

### DIFF
--- a/custom_components/beny_wifi/coordinator.py
+++ b/custom_components/beny_wifi/coordinator.py
@@ -416,6 +416,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Apply any supplied overrides
         if dlb_enabled is not None:
             cfg["dlb_enabled"] = 0x01 if dlb_enabled else 0x00
+
+        if extreme_mode is not None:
             cfg["extreme"] = 0x01 if extreme_mode else 0x00
 
         if night_mode is not None:


### PR DESCRIPTION
# Fix Extreme Mode toggle reverting after coordinator update

## Description

This PR fixes a bug where enabling the **Extreme Mode** switch would appear to work momentarily, then revert to off a few seconds later. The root cause was two separate defects in `async_set_dlb_config()` in `coordinator.py`, both in the same block of code.

---

## Changes Made

### Bug 1 — `extreme_mode` was never written to the config cache

There was no `if extreme_mode is not None:` guard block anywhere in `async_set_dlb_config()`. The `extreme_mode` parameter was accepted by the function signature but never actually applied to `cfg["extreme"]`. Toggling Extreme Mode sent the correct byte to the charger on the first call, but the cache remained `0x00`, so the next coordinator poll would overwrite it back to off.

### Bug 2 — `dlb_enabled` block was unconditionally clobbering `extreme`

The `dlb_enabled` update block contained a spurious line that reset `cfg["extreme"]` as a side effect:

```python
# Before — BUG
if dlb_enabled is not None:
    cfg["dlb_enabled"] = 0x01 if dlb_enabled else 0x00
    cfg["extreme"] = 0x01 if extreme_mode else 0x00  # ← always ran when dlb_enabled changed
```

Any call that touched `dlb_enabled` (e.g. toggling the master PV Dynamic Load Balance switch) would reset `extreme` to `0x00` because `extreme_mode` is `None` in those calls — and `None` is falsy.

### Fix

The two concerns are now separated into independent guards, matching the pattern used correctly by every other field (`night_mode`, `anti_overload`, etc.):

```python
# After — FIXED
if dlb_enabled is not None:
    cfg["dlb_enabled"] = 0x01 if dlb_enabled else 0x00

if extreme_mode is not None:
    cfg["extreme"] = 0x01 if extreme_mode else 0x00
```

---

## Implementation Notes

- Change is entirely contained in `coordinator.py` — no entity files, protocol layer, or config flow affected.
- All other DLB config fields (`night_mode`, `dlb_mode`, `anti_overload`, etc.) were already using the correct independent-guard pattern and are unaffected.
- The optimistic state handling in `BenyWifiExtremeModeSwitch` (which correctly snaps the UI on press and clears on coordinator refresh) was not at fault and is unchanged.

---

## Testing

- **Hardware**: Beny Charger BCP-A2N-L (firmware 1.28) with Solar DLB module
- **Verified**: Extreme Mode toggle now persists correctly across coordinator refresh cycles
- **Regression**: All other DLB switches (PV Dynamic Load Balance, Night Mode, Anti Overload) confirmed unaffected — toggling each no longer has any side effect on the others

---

## Breaking Changes

None. The fix aligns the cache update behaviour with what the function signature already promised.

---

## Checklist

- [x] Root cause identified and confirmed via log analysis
- [x] Both defects fixed in a single minimal change to `coordinator.py`
- [x] Extreme Mode verified to persist correctly after coordinator refresh
- [x] No regression on other DLB config fields
- [x] No changes required outside `coordinator.py`
- [x] All modified files pass Python syntax check