### PR TITLE
Fix Hybrid mode current range

### DIFF
--- a/custom_components/beny_wifi/coordinator.py
+++ b/custom_components/beny_wifi/coordinator.py
@@ -42,6 +42,16 @@ DEFAULT_NIGHT_END = 6     # 6am
 # scan interval so behaviour is consistent regardless of polling rate.
 _STALE_WINDOW_SECONDS = 180  # ~3 minutes
 
+# Valid hybrid current range.
+# Byte12 of SET_DLB_CONFIG encodes the hybrid current directly.
+# Values 0x00 (PURE_PV), 0x63/99 (FULL_SPEED), and 0xFF (DLB_BOX) are
+# sentinel values used by the charger for non-hybrid modes.
+# Therefore 99 (0x63) must be excluded from the hybrid range even though
+# the Z-Box app labels its slider as 1–99: sending 99 would engage FULL_SPEED.
+# The practical safe range is 1–98.
+HYBRID_CURRENT_MIN = 1
+HYBRID_CURRENT_MAX = 98
+
 
 class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Beny Wifi update coordinator."""
@@ -483,7 +493,9 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             device_name:         Human-readable device label for logging.
             dlb_enabled:         True to enable PV Dynamic Load Balance, False to disable.
             dlb_mode:            DLB_MODE enum value. For HYBRID, also supply hybrid_current.
-            hybrid_current:      Current limit in amps (6-32) when dlb_mode=HYBRID.
+            hybrid_current:      Current limit in amps (1-98) when dlb_mode=HYBRID.
+                                 Range is 1-98 (not 1-99) because byte value 99 (0x63) is
+                                 the FULL_SPEED sentinel and would be misinterpreted by the charger.
             extreme_mode:        True to enable Extreme Mode, False to disable.
             night_mode:          True to enable Night Mode, False to disable.
             night_start:         Night mode start hour (0-23, 24h).
@@ -515,10 +527,15 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if dlb_mode is not None:
             if dlb_mode == DLB_MODE.HYBRID:
-                # For hybrid, byte12 carries the actual current limit
+                # For hybrid, byte12 carries the actual current limit.
+                # Valid range is HYBRID_CURRENT_MIN–HYBRID_CURRENT_MAX (1–98).
+                # 99 (0x63) is excluded because it is the FULL_SPEED sentinel value.
                 current = hybrid_current if hybrid_current is not None else cfg["hybrid_current"]
-                if not (6 <= current <= 32):
-                    raise ValueError("hybrid_current must be between 6 and 32 amps")
+                if not (HYBRID_CURRENT_MIN <= current <= HYBRID_CURRENT_MAX):
+                    raise ValueError(
+                        f"hybrid_current must be between {HYBRID_CURRENT_MIN} and {HYBRID_CURRENT_MAX} amps "
+                        f"(99 is reserved as the FULL_SPEED sentinel)"
+                    )
                 cfg["hybrid_current"] = current
                 cfg["dlb_mode"] = current  # byte12 = amps value directly
             else:

--- a/custom_components/beny_wifi/number.py
+++ b/custom_components/beny_wifi/number.py
@@ -23,6 +23,7 @@ from .const import (
     get_device_id, 
     get_config_parameter
 )
+from .coordinator import HYBRID_CURRENT_MIN, HYBRID_CURRENT_MAX
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,7 +139,12 @@ class BenyWifiMaxCurrentNumber(BenyWifiBaseNumber):
         return False
 
 class BenyWifiHybridCurrentNumber(BenyWifiBaseNumber):
-    """Current limit for Hybrid DLB mode (1–32 A).
+    """Current limit for Hybrid DLB mode (1–98 A).
+
+    The valid range is 1–98A. Although the Z-Box app labels its slider as 1–99,
+    the value 99 (0x63) is the FULL_SPEED sentinel byte and would be misinterpreted
+    by the charger as a mode switch rather than a current limit. 98A is the safe
+    maximum for hybrid current.
 
     Adjusting this while already in Hybrid mode immediately resends the config.
     Adjusting it in any other mode stores the value ready for the next switch.
@@ -146,7 +152,10 @@ class BenyWifiHybridCurrentNumber(BenyWifiBaseNumber):
 
     def __init__(self, coordinator, key, serial=None, device_model=None):
         """Initialize."""
-        super().__init__(coordinator, key, serial=serial, device_model=device_model, min_value=1, max_value=32)
+        super().__init__(
+            coordinator, key, serial=serial, device_model=device_model,
+            min_value=HYBRID_CURRENT_MIN, max_value=HYBRID_CURRENT_MAX,
+        )
         self._attr_icon = "mdi:current-ac"
         self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_mode = NumberMode.SLIDER
@@ -164,8 +173,11 @@ class BenyWifiHybridCurrentNumber(BenyWifiBaseNumber):
 
         self.coordinator._dlb_config["hybrid_current"] = current
 
+        # Detect Hybrid mode: byte12 holds the current value directly.
+        # Valid hybrid range is HYBRID_CURRENT_MIN–HYBRID_CURRENT_MAX (1–98).
+        # Values 0 (PURE_PV), 99/0x63 (FULL_SPEED), and 255/0xFF (DLB_BOX) are sentinels.
         raw = self.coordinator._dlb_config.get("dlb_mode")
-        if raw is not None and 1 <= raw <= 32:
+        if raw is not None and HYBRID_CURRENT_MIN <= raw <= HYBRID_CURRENT_MAX:
             await self.coordinator.async_set_dlb_config(
                 device_name,
                 dlb_mode=DLB_MODE.HYBRID,

--- a/custom_components/beny_wifi/select.py
+++ b/custom_components/beny_wifi/select.py
@@ -17,6 +17,7 @@ from .const import (
     get_device_id,
     get_config_parameter,
 )
+from .coordinator import HYBRID_CURRENT_MIN, HYBRID_CURRENT_MAX
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,6 +77,10 @@ class BenyWifiDlbModeSelect(CoordinatorEntity, SelectEntity):
              so the UI snaps to the new value without waiting for a poll).
           2. Coordinator's _dlb_config cache (authoritative after any command).
           3. Safe default.
+
+        Hybrid mode detection: byte12 stores the current limit directly (1–98A).
+        Sentinel values are: 0x00=PURE_PV, 0x63/99=FULL_SPEED, 0xFF=DLB_BOX.
+        Any byte12 value in the range HYBRID_CURRENT_MIN–HYBRID_CURRENT_MAX is Hybrid.
         """
         if self._optimistic_label is not None:
             return self._optimistic_label
@@ -88,7 +93,7 @@ class BenyWifiDlbModeSelect(CoordinatorEntity, SelectEntity):
                 return _MODE_TO_LABEL[DLB_MODE.FULL_SPEED]
             elif raw == DLB_MODE.DLB_BOX.value:
                 return _MODE_TO_LABEL[DLB_MODE.DLB_BOX]
-            elif 1 <= raw <= 32:
+            elif HYBRID_CURRENT_MIN <= raw <= HYBRID_CURRENT_MAX:
                 return _MODE_TO_LABEL[DLB_MODE.HYBRID]
 
         return _MODE_TO_LABEL[DLB_MODE.DLB_BOX]

--- a/custom_components/beny_wifi/services.yaml
+++ b/custom_components/beny_wifi/services.yaml
@@ -197,13 +197,16 @@ set_dlb_config:
               value: "pure_pv"
     hybrid_current:
       name: "Hybrid Current Limit"
-      description: "Current limit in amps when DLB Mode is set to Hybrid (6–32A)."
+      description: >
+        Current limit in amps when DLB Mode is set to Hybrid (1–98A).
+        Note: 99A is not available — that value is reserved as the charger's
+        Full Speed sentinel and would switch the mode rather than set a current limit.
       required: false
       example: 16
       selector:
         number:
-          min: 6
-          max: 32
+          min: 1
+          max: 98
           step: 1
           unit_of_measurement: "A"
           mode: slider


### PR DESCRIPTION
# Fix: Hybrid mode current range extended to 1–98A

This PR fixes the following issues:

1. **Hybrid DLB mode failing when current is set below 6A** — selecting Hybrid mode after setting a current value of 1–5A raised a validation error and refused to apply the config
2. **Hybrid mode misdetected for current values above 32A** — the `select` entity and `number` entity both used a hardcoded `1–32A` range to identify Hybrid mode, meaning any stored hybrid current above 32A would cause the select entity to fall back to DLB Box and the number entity to skip re-sending the config to the charger

---

## Changes Made

### Bug 1 & 2 — Incorrect hybrid current range across coordinator, number, and select (`coordinator.py`, `number.py`, `select.py`, `services.yaml`)

#### Root cause

The hybrid current range was independently hardcoded in four separate places with inconsistent values:

- `coordinator.py` `async_set_dlb_config`: validated as `6 <= current <= 32`, raising `ValueError` for any value outside this range
- `number.py` `BenyWifiHybridCurrentNumber`: slider `min_value=1, max_value=32`
- `number.py` `async_set_native_value`: Hybrid mode detection used `1 <= raw <= 32`
- `select.py` `current_option`: Hybrid mode detection used `1 <= raw <= 32`
- `services.yaml`: `hybrid_current` selector declared `min: 6, max: 32`

The Z-Box app allows setting hybrid current from **1–99A**, but the integration rejected anything below 6A at the coordinator level. Additionally, 32A was used as the upper bound for Hybrid mode detection throughout, meaning stored values of 33–98A would be silently misidentified as a different mode.

A further protocol constraint was identified during this fix: `FULL_SPEED = 0x63` in the `DLB_MODE` enum is decimal **99**. Since byte12 of `SET_DLB_CONFIG` encodes the hybrid current as a raw integer, sending value `99` would be misinterpreted by the charger as "switch to Full Speed" rather than "set 99A limit". The true safe maximum is therefore **98A**.

#### Fix

Two module-level constants `HYBRID_CURRENT_MIN = 1` and `HYBRID_CURRENT_MAX = 98` are introduced in `coordinator.py` as the single source of truth and imported into `number.py` and `select.py`. This eliminates the risk of the four locations drifting out of sync again.

```python
# coordinator.py — Before: hardcoded 6–32A
if not (6 <= current <= 32):
    raise ValueError("hybrid_current must be between 6 and 32 amps")

# coordinator.py — After: 1–98A with explanation
if not (HYBRID_CURRENT_MIN <= current <= HYBRID_CURRENT_MAX):
    raise ValueError(
        f"hybrid_current must be between {HYBRID_CURRENT_MIN} and {HYBRID_CURRENT_MAX} amps "
        f"(99 is reserved as the FULL_SPEED sentinel)"
    )
```

```python
# number.py — Before: slider hardcoded to 1–32A
super().__init__(coordinator, key, ..., min_value=1, max_value=32)

# number.py — After: driven by shared constants
super().__init__(coordinator, key, ..., min_value=HYBRID_CURRENT_MIN, max_value=HYBRID_CURRENT_MAX)
```

```python
# select.py / number.py — Before: Hybrid detection capped at 32A
elif 1 <= raw <= 32:
    return _MODE_TO_LABEL[DLB_MODE.HYBRID]

# select.py / number.py — After: Hybrid detection covers full valid range
elif HYBRID_CURRENT_MIN <= raw <= HYBRID_CURRENT_MAX:
    return _MODE_TO_LABEL[DLB_MODE.HYBRID]
```

---

## Implementation Notes

- `coordinator.py`: `HYBRID_CURRENT_MIN` and `HYBRID_CURRENT_MAX` are the single source of truth for the valid hybrid current range. All validation and detection logic references these constants.
- `number.py` and `select.py`: Both import the constants from `coordinator.py` — no values are duplicated.
- `services.yaml`: `hybrid_current` selector updated to `min: 1, max: 98` with an explanatory description noting why 99A is excluded.
- No changes to config entry structure, entity IDs, service interfaces, or any non-DLB logic.

---

## Testing

- **Hardware**: Beny Charger BCP-A2N-L (firmware 1.28) with Solar DLB module
- **Verified**:
  - Hybrid current can be set to 1A via the number entity slider without error
  - Selecting Hybrid mode after setting a sub-6A current correctly sends the config to the charger
  - Select entity correctly reports Hybrid mode for stored current values across the full 1–98A range
  - Setting 98A hybrid current correctly encodes as `0x62` in byte12; 99 (0x63) correctly maps to Full Speed and is blocked from the hybrid current path
  - All other DLB modes (Pure PV, Full Speed, DLB Box) unaffected

---

## Breaking Changes

None. The valid current range is widened, not narrowed. Existing configurations with hybrid current values in the previously accepted 6–32A range continue to work without modification.

---

## Checklist

- [x] Root cause identified for all bugs
- [x] `FULL_SPEED = 0x63` (99) sentinel conflict identified and documented
- [x] `coordinator.py`: shared `HYBRID_CURRENT_MIN` / `HYBRID_CURRENT_MAX` constants introduced
- [x] `coordinator.py`: `async_set_dlb_config` validation updated to 1–98A
- [x] `number.py`: slider range and Hybrid detection updated via shared constants
- [x] `select.py`: Hybrid mode detection updated via shared constants
- [x] `services.yaml`: `hybrid_current` selector updated to `min: 1, max: 98`
- [x] Verified correct charger behaviour at boundary values (1A, 98A)
- [x] All modified files pass Python syntax check