### PR TITLE
Improved live data polling

### DIFF
--- a/custom_components/beny_wifi/__init__.py
+++ b/custom_components/beny_wifi/__init__.py
@@ -8,13 +8,13 @@ from .const import (
     CONF_ANTI_OVERLOAD_VALUE,
     DEFAULT_ANTI_OVERLOAD,
     DEFAULT_ANTI_OVERLOAD_VALUE,
+    DLB,
     DOMAIN, 
     IP_ADDRESS, 
     PLATFORMS, 
     PORT, 
     DEFAULT_PORT,
     SCAN_INTERVAL, 
-    DLB, 
     CONF_MAX_CURRENT_MIN, 
     CONF_MAX_CURRENT_MAX, 
     DEFAULT_MAX_CURRENT_MIN, 
@@ -29,7 +29,7 @@ from .const import (
     SECTION_DLB,
     get_config_parameter
 )
-from .coordinator import BenyWifiUpdateCoordinator
+from .coordinator import BenyWifiUpdateCoordinator, BenyWifiLiveCoordinator
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,33 +46,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if entry.unique_id != serial_str:
             hass.config_entries.async_update_entry(entry, unique_id=serial_str)
     
-    
     ip_address = get_config_parameter(entry, SECTION_CONNECTION, IP_ADDRESS)
     port = get_config_parameter(entry, SECTION_CONNECTION, PORT)
-    # Use DEFAULT_SCAN_INTERVAL (30 seconds) if not configured
+    # Use DEFAULT_SCAN_INTERVAL if not configured
     scan_interval = get_config_parameter(entry, SECTION_CONNECTION, SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    _LOGGER.info(f"Using scan interval: {scan_interval} seconds")
-    
-    # FIXED: Pass entry as the second parameter
+    _LOGGER.info(f"Using scan interval: {scan_interval} seconds for main coordinator")
+
+    # Main coordinator — charger state, energy, faults, timers, DLB config
     coordinator = BenyWifiUpdateCoordinator(hass, entry, ip_address, port, scan_interval)
-    
+
     # Perform the first update to ensure connection works
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as ex:
         _LOGGER.error(f"Error setting up coordinator: {ex}")
         raise ConfigEntryNotReady from ex
-    
-    # Store the coordinator for use by platforms
+
+    # Live coordinator — power, current, and DLB power at 5-second intervals
+    live_coordinator = BenyWifiLiveCoordinator(hass, entry, ip_address, port, coordinator)
+    try:
+        await live_coordinator.async_config_entry_first_refresh()
+    except Exception as ex:
+        # Non-fatal: live data will catch up on the next poll cycle.
+        # The integration can still function with slower data from the main coordinator.
+        _LOGGER.warning(f"Live coordinator first refresh failed (non-fatal): {ex}")
+
+    # Store both coordinators for use by platforms
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": coordinator,
+        "live_coordinator": live_coordinator,
     }
     
     # Forward entry setup to supported platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     
-    # setup services
+    # Setup services
     await async_setup_services(hass)
     
     return True

--- a/custom_components/beny_wifi/coordinator.py
+++ b/custom_components/beny_wifi/coordinator.py
@@ -43,6 +43,14 @@ DEFAULT_NIGHT_END = 6     # 6am
 # scan interval so behaviour is consistent regardless of polling rate.
 _STALE_WINDOW_SECONDS = 180  # ~3 minutes
 
+# Fast-poll interval for live data (power, current, DLB power)
+LIVE_POLL_INTERVAL = 5  # seconds
+
+# Number of consecutive failed live polls before a field's cached value is
+# evicted and the sensor falls back to unavailable.
+# 3 polls = 15 seconds of tolerance for transient UDP failures.
+_LIVE_CACHE_MISS_THRESHOLD = 3
+
 # Valid hybrid current range.
 # Byte12 of SET_DLB_CONFIG encodes the hybrid current directly.
 # Values 0x00 (PURE_PV), 0x63/99 (FULL_SPEED), and 0xFF (DLB_BOX) are
@@ -55,7 +63,19 @@ HYBRID_CURRENT_MAX = 98
 
 
 class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Beny Wifi update coordinator."""
+    """Beny Wifi update coordinator.
+
+    Handles slow-changing data: charger state, energy totals, temperature,
+    timer/schedule settings, fault status, and DLB config.
+    Fast-changing live data (power, current, DLB power) is handled by
+    BenyWifiLiveCoordinator which polls at LIVE_POLL_INTERVAL seconds.
+
+    Owns a shared asyncio.Lock (_udp_lock) that both this coordinator and
+    BenyWifiLiveCoordinator must hold before sending any UDP request.  This
+    ensures the two coordinators never talk to the charger simultaneously,
+    which previously caused one request to receive the other's response
+    (wrong checksum → UpdateFailed → brief "unavailable" state).
+    """
 
     def __init__(
         self,
@@ -79,14 +99,17 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.hass = hass
         self._dlb_config_loaded = False  # set True after first successful read from charger
 
-        # Derive the stale threshold from the configured scan interval so that
-        # DLB fields always go unavailable after ~3 minutes of missing data,
-        # regardless of how fast or slow polling is set.
+        # Shared mutex: only one UDP conversation may be in flight at a time.
+        # BenyWifiLiveCoordinator receives a reference to this lock in __init__.
+        self._udp_lock: asyncio.Lock = asyncio.Lock()
+
+        # Derive the stale threshold from the live poll interval so that
+        # DLB fields always go unavailable after ~3 minutes of missing data.
         # Minimum of 3 polls is kept so a single transient failure never triggers it.
-        self.STALE_THRESHOLD = max(3, round(_STALE_WINDOW_SECONDS / scan_interval))
+        self.STALE_THRESHOLD = max(3, round(_STALE_WINDOW_SECONDS / LIVE_POLL_INTERVAL))
         _LOGGER.debug(
             f"STALE_THRESHOLD set to {self.STALE_THRESHOLD} polls "  # noqa: G004
-            f"({scan_interval}s interval → ~{self.STALE_THRESHOLD * scan_interval}s stale window)"
+            f"({LIVE_POLL_INTERVAL}s live interval → ~{self.STALE_THRESHOLD * LIVE_POLL_INTERVAL}s stale window)"
         )
 
         # Resolve Anti Overload initial values from config entry data.
@@ -120,7 +143,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if persisted:
             _LOGGER.debug(f"DLB config restored from config_entry.options: {self._dlb_config}")  # noqa: G004
 
-        # Tracks consecutive polls where a field returned None (sentinel/missing).
+        # Tracks consecutive polls where a DLB field returned None (sentinel/missing).
+        # Incremented by BenyWifiLiveCoordinator; read by BenyWifiPowerSensor.available.
         # Once a field hits STALE_THRESHOLD, is_field_stale() returns True so
         # sensors can mark themselves unavailable instead of showing stale data.
         self._stale_counts: dict[str, int] = {}
@@ -144,19 +168,11 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._stale_counts[field] = 0
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data asynchronously.
-
-        If the entire fetch fails (device unreachable, UDP timeout, etc.) we still
-        increment stale counts for all DLB fields so they tip to unavailable after
-        STALE_THRESHOLD missed polls, just as they would for per-field sentinel failures.
-        """
-        try:
+        """Fetch data asynchronously."""
+        # Acquire the shared lock so that live coordinator polls are held off
+        # while the (slower) main poll occupies the UDP socket.
+        async with self._udp_lock:
             return await self._fetch_data()
-        except UpdateFailed:
-            if get_config_parameter(self.config_entry, SECTION_DLB, DLB, False):
-                for key in ("grid_power", "house_power", "ev_power", "solar_power"):
-                    self._update_stale_count(key, None)
-            raise
 
     async def async_read_dlb_config(self) -> bool:
         """Attempt to read current DLB config from charger to populate _dlb_config cache.
@@ -197,7 +213,14 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug(f"DLB config persisted to config_entry.options: {self._dlb_config}")  # noqa: G004
 
     async def _fetch_data(self):
-        """Send UDP request and fetch data asynchronously."""
+        """Send UDP request and fetch data asynchronously.
+
+        Fetches: charger state, energy, temperature, timer, faults, DLB config.
+        Does NOT fetch power, current, or DLB power — those are handled by
+        BenyWifiLiveCoordinator at LIVE_POLL_INTERVAL seconds.
+
+        Caller is expected to hold _udp_lock before calling this method.
+        """
 
         # On the first successful fetch, attempt to read DLB config directly from
         # the charger so entities reflect actual state rather than defaults/persisted cache.
@@ -216,14 +239,14 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             start_time = time.monotonic()
             response_raw = await loop.run_in_executor(None, self._send_udp_request, request)
             latency = time.monotonic() - start_time
-            
+
             # Decode and parse the response
             response_str = response_raw.decode('ascii')
-            
+
             # Authentication failed
             if "55aa100008" in response_str:
                 raise Exception("Authentication failed, check PIN")
-        
+
             data = read_message(response_str)
 
             if data is None:
@@ -279,45 +302,11 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             data['charger_state'] = data['state'].lower()
 
-            data['power'] = float(data['power']) / 10
             data['total_kwh'] = float(data['total_kwh'])
             data['temperature'] = int(data['temperature'] - 100)
 
-            # DLB data fetch — isolated so a DLB failure doesn't discard valid charger data
-            if get_config_parameter(self.config_entry, SECTION_DLB, DLB):
-                try:
-                    request = build_message(
-                        CLIENT_MESSAGE.REQUEST_DLB,
-                        {"pin": get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN), "request_type": get_hex(REQUEST_TYPE.DLB.value)}
-                    ).encode('ascii')
-
-                    loop = asyncio.get_running_loop()
-                    response_dlb = await loop.run_in_executor(None, self._send_udp_request, request)
-                    response_dlb = response_dlb.decode('ascii')
-                    data_dlb = read_message(response_dlb)
-
-                    if data_dlb is None:
-                        _LOGGER.warning("DLB response had invalid checksum — skipping DLB data this cycle")
-                        for key in ("grid_power", "house_power", "ev_power", "solar_power"):
-                            self._update_stale_count(key, None)
-                    else:
-                        # Track staleness per field. None means the charger sent a sentinel
-                        # (0xFF00+) indicating DLB data is temporarily unavailable.
-                        # Only assign valid values so sensors can retain last known state
-                        # until is_field_stale() tips them to unavailable after STALE_THRESHOLD.
-                        for key in ("grid_power", "house_power", "ev_power", "solar_power"):
-                            val = data_dlb.get(key)
-                            self._update_stale_count(key, val)
-                            if val is not None:
-                                data[key] = val
-
-                except Exception as dlb_err:
-                    _LOGGER.warning(
-                        f"DLB fetch failed (non-fatal): {dlb_err} — DLB sensors will retain last valid value"
-                    )
-                    for key in ("grid_power", "house_power", "ev_power", "solar_power"):
-                        self._update_stale_count(key, None)
-                    # Do not re-raise: the primary charger data is still valid
+            # NOTE: power and current values are intentionally NOT processed here.
+            # They are fetched at LIVE_POLL_INTERVAL by BenyWifiLiveCoordinator.
 
             # Fetch detailed fault status
             try:
@@ -327,7 +316,7 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ).encode('ascii')
                 response_status_raw = await loop.run_in_executor(None, self._send_udp_request, request_status)
                 data_status = read_message(response_status_raw.decode('ascii'))
-                
+
                 fault_mapping = {
                     "over_voltage": "over_voltage",
                     "under_voltage": "under_voltage",
@@ -356,7 +345,7 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         data[f"{label}_fault"] = is_active
                         if is_active:
                             active_faults.append(label)
-                    
+
                     data["fault_code"] = active_faults[0] if active_faults else "none"
                 else:
                     # Fallback: use the summary fault code from the main values packet
@@ -371,7 +360,6 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception as status_err:
                 _LOGGER.debug(f"Failed to fetch detailed fault status: {status_err}")
                 data["fault_code"] = "Unknown"
-
 
             # Expose current DLB config state so entities can read it
             data['dlb_config'] = dict(self._dlb_config)
@@ -430,7 +418,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return
 
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._send_udp_request, request)
+            async with self._udp_lock:
+                await loop.run_in_executor(None, self._send_udp_request, request)
             _LOGGER.info(f"{device_name}: {command} charging command sent")
 
     async def async_set_max_monthly_consumption(self, device_name: str, maximum_consumption: int):
@@ -438,7 +427,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         request = build_message(CLIENT_MESSAGE.SET_MAX_MONTHLY_CONSUMPTION, {"pin": get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN), "maximum_consumption": get_hex(maximum_consumption, 4)}).encode('ascii')
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._send_udp_request, request)
+        async with self._udp_lock:
+            await loop.run_in_executor(None, self._send_udp_request, request)
 
         _LOGGER.info(f"{device_name}: maximum consumption set")
 
@@ -447,7 +437,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         request = build_message(CLIENT_MESSAGE.SET_MAX_SESSION_CONSUMPTION, {"pin": get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN), "maximum_consumption": get_hex(maximum_consumption)}).encode('ascii')
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._send_udp_request, request)
+        async with self._udp_lock:
+            await loop.run_in_executor(None, self._send_udp_request, request)
 
         _LOGGER.info(f"{device_name}: maximum consumption set")
 
@@ -462,7 +453,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             timer_data['pin'] = get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN)
             request = build_message(CLIENT_MESSAGE.SET_TIMER, timer_data).encode('ascii')
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._send_udp_request, request)
+            async with self._udp_lock:
+                await loop.run_in_executor(None, self._send_udp_request, request)
 
             _LOGGER.info(f"{device_name}: charging timer set")
 
@@ -472,7 +464,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         schedule_data['pin'] = get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN)
         request = build_message(CLIENT_MESSAGE.SET_SCHEDULE, schedule_data).encode('ascii')
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._send_udp_request, request)
+        async with self._udp_lock:
+            await loop.run_in_executor(None, self._send_udp_request, request)
 
         _LOGGER.info(f"{device_name}: charging schedule set")
 
@@ -485,7 +478,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if state_sensor_value and state_sensor_value.state != CHARGER_STATE.UNPLUGGED.name.lower():
             request = build_message(CLIENT_MESSAGE.RESET_TIMER, {"pin": get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN)}).encode('ascii')
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._send_udp_request, request)
+            async with self._udp_lock:
+                await loop.run_in_executor(None, self._send_udp_request, request)
 
             _LOGGER.info(f"{device_name}: charging timer reset")
 
@@ -494,7 +488,9 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         request = build_message(CLIENT_MESSAGE.REQUEST_SETTINGS, {"pin": get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN)}).encode('ascii')
         loop = asyncio.get_running_loop()
-        response = await loop.run_in_executor(None, self._send_udp_request, request)
+        async with self._udp_lock:
+            response = await loop.run_in_executor(None, self._send_udp_request, request)
+
         # Decode and parse the response
         response = response.decode('ascii')
         data = read_message(response, SERVER_MESSAGE.SEND_SETTINGS)
@@ -524,7 +520,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ).encode("ascii")
 
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._send_udp_request, request)
+        async with self._udp_lock:
+            await loop.run_in_executor(None, self._send_udp_request, request)
 
         _LOGGER.info(f"{device_name}: max current set to {max_current}A")
 
@@ -639,7 +636,8 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ).encode("ascii")
 
         loop = asyncio.get_running_loop()
-        response = await loop.run_in_executor(None, self._send_udp_request, request)
+        async with self._udp_lock:
+            response = await loop.run_in_executor(None, self._send_udp_request, request)
 
         # Parse the ACK — the charger echoes back the full config it applied.
         # This confirms what was stored and keeps _dlb_config in sync,
@@ -667,3 +665,216 @@ class BenyWifiUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f"night={cfg['night']:#04x} "
             f"night_start={cfg['night_start']} night_end={cfg['night_end']}"
         )
+
+
+class BenyWifiLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Fast-polling coordinator for live sensor data.
+
+    Polls at LIVE_POLL_INTERVAL (5 seconds) and fetches:
+      - Power and current readings (1P: power, current1, voltage1; 3P: all phases)
+      - DLB power readings (grid, solar, EV, house) when DLB is enabled
+
+    Shares the main coordinator's stale-count tracking for DLB fields so that
+    BenyWifiPowerSensor.available works correctly regardless of which coordinator
+    owns the DLB sensors.
+
+    Uses a short UDP timeout (3s, no retries) to ensure each poll finishes well
+    within the 5-second interval.  Failures are handled by value caching: the last
+    known valid value for each field is retained for up to _LIVE_CACHE_MISS_THRESHOLD
+    consecutive failed polls before being evicted.  This prevents brief UDP hiccups
+    from causing "unavailable" flashes in the UI.
+
+    Collision avoidance: acquires the main coordinator's _udp_lock before sending
+    any UDP request.  If the main coordinator is mid-poll the live poll simply waits
+    rather than sending a concurrent request that would confuse the charger.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry,
+        ip_address: str,
+        port: int,
+        main_coordinator: BenyWifiUpdateCoordinator,
+    ) -> None:
+        """Initialize the live coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_live",
+            update_interval=timedelta(seconds=LIVE_POLL_INTERVAL),
+        )
+        self.config_entry = config_entry
+        self.ip_address = ip_address
+        self.port = port
+        # Reference to the main coordinator — used to share stale-count state,
+        # _dlb_config, and the UDP lock.
+        self._main = main_coordinator
+
+        # Per-field value cache: stores the last successfully received value.
+        # Returned on failed polls so sensors stay populated instead of going unavailable.
+        self._cached_data: dict[str, Any] = {}
+
+        # Per-field miss counter: tracks consecutive polls where a field was absent
+        # or None in the device response.  Once this hits _LIVE_CACHE_MISS_THRESHOLD
+        # the cached value is evicted so the sensor can honestly go unavailable.
+        self._miss_counts: dict[str, int] = {}
+
+    def is_field_stale(self, field: str) -> bool:
+        """Delegate stale check to main coordinator."""
+        return self._main.is_field_stale(field)
+
+    # ------------------------------------------------------------------
+    # Internal cache helpers
+    # ------------------------------------------------------------------
+
+    def _record_hit(self, field: str, value: Any) -> None:
+        """Store a freshly received value and reset its miss counter."""
+        self._cached_data[field] = value
+        self._miss_counts[field] = 0
+
+    def _record_miss(self, field: str) -> None:
+        """Increment miss counter; evict cache entry once threshold is reached."""
+        count = self._miss_counts.get(field, 0) + 1
+        self._miss_counts[field] = count
+        if count >= _LIVE_CACHE_MISS_THRESHOLD:
+            if field in self._cached_data:
+                _LOGGER.debug(
+                    f"Live cache: evicting '{field}' after {count} consecutive misses"  # noqa: G004
+                )
+                del self._cached_data[field]
+        else:
+            _LOGGER.debug(
+                f"Live cache: '{field}' miss {count}/{_LIVE_CACHE_MISS_THRESHOLD} — "  # noqa: G004
+                f"serving cached value"
+            )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch live power, current, and DLB data.
+
+        Always returns a data dict (never raises UpdateFailed directly) so that
+        CoordinatorEntity.available stays True as long as cached values exist.
+        The live coordinator's last_update_success is set to True whenever we
+        have something meaningful to return, even if it came from the cache.
+        """
+        # Start with an empty result; we'll populate from fresh data + cache below.
+        fresh: dict[str, Any] = {}
+
+        pin = get_config_parameter(self.config_entry, SECTION_DEVICE, CONF_PIN)
+        loop = asyncio.get_running_loop()
+
+        # Acquire the shared UDP lock.  If the main coordinator is currently mid-poll
+        # this will block here (typically < 500 ms) until it finishes — preventing
+        # simultaneous UDP traffic that previously triggered "unavailable" flashes.
+        async with self._main._udp_lock:
+
+            # --- Main values packet (power + current + voltage) ---
+            try:
+                request = build_message(
+                    CLIENT_MESSAGE.REQUEST_DATA,
+                    {"pin": pin, "request_type": get_hex(REQUEST_TYPE.VALUES.value)}
+                ).encode('ascii')
+
+                response_raw = await loop.run_in_executor(None, self._send_live_udp, request)
+                response_str = response_raw.decode('ascii')
+                parsed = read_message(response_str)
+
+                if parsed is not None:
+                    # Power (stored in 100W units in the packet → divide by 10 for kW)
+                    if "power" in parsed:
+                        fresh["power"] = float(parsed["power"]) / 10
+
+                    # Currents — include all phase keys present in the packet
+                    for key in ("current1", "current2", "current3", "max_current"):
+                        if key in parsed:
+                            fresh[key] = parsed[key]
+
+                    # Voltages — also fast-changing on 3P units
+                    for key in ("voltage1", "voltage2", "voltage3"):
+                        if key in parsed:
+                            fresh[key] = parsed[key]
+                else:
+                    _LOGGER.debug("Live values packet had invalid checksum — skipping this cycle")
+
+            except Exception as err:
+                _LOGGER.debug(f"Live values fetch failed (non-fatal): {err}")
+
+            # --- DLB power packet ---
+            if get_config_parameter(self.config_entry, SECTION_DLB, DLB, False):
+                try:
+                    request_dlb = build_message(
+                        CLIENT_MESSAGE.REQUEST_DLB,
+                        {"pin": pin, "request_type": get_hex(REQUEST_TYPE.DLB.value)}
+                    ).encode('ascii')
+
+                    response_dlb = await loop.run_in_executor(None, self._send_live_udp, request_dlb)
+                    data_dlb = read_message(response_dlb.decode('ascii'))
+
+                    if data_dlb is None:
+                        _LOGGER.debug("Live DLB packet had invalid checksum — skipping DLB data this cycle")
+                        for key in ("grid_power", "house_power", "ev_power", "solar_power"):
+                            self._main._update_stale_count(key, None)
+                    else:
+                        for key in ("grid_power", "house_power", "ev_power", "solar_power"):
+                            val = data_dlb.get(key)
+                            self._main._update_stale_count(key, val)
+                            if val is not None:
+                                fresh[key] = val
+
+                except Exception as dlb_err:
+                    _LOGGER.debug(
+                        f"Live DLB fetch failed (non-fatal): {dlb_err} — DLB sensors will retain cached value"
+                    )
+                    for key in ("grid_power", "house_power", "ev_power", "solar_power"):
+                        self._main._update_stale_count(key, None)
+
+        # ------------------------------------------------------------------
+        # Merge fresh data into the per-field cache and build the return dict.
+        #
+        # All fields tracked by the live coordinator (both values and DLB) go
+        # through the same hit/miss accounting so the logic is uniform.
+        # ------------------------------------------------------------------
+        _all_live_fields = (
+            "power",
+            "current1", "current2", "current3", "max_current",
+            "voltage1", "voltage2", "voltage3",
+            "grid_power", "solar_power", "ev_power", "house_power",
+        )
+
+        result: dict[str, Any] = {}
+
+        for field in _all_live_fields:
+            if field in fresh:
+                # Fresh value received — update cache and include in result.
+                self._record_hit(field, fresh[field])
+                result[field] = fresh[field]
+            elif field in self._cached_data:
+                # No fresh value this cycle — serve cached value and record miss.
+                self._record_miss(field)
+                # After eviction _cached_data no longer has the field; check again.
+                if field in self._cached_data:
+                    result[field] = self._cached_data[field]
+            # else: field has no fresh value and no cached value — omit from result.
+
+        return result
+
+    def _send_live_udp(self, request: bytes) -> bytes:
+        """Send a UDP request with a tight timeout suited to the 5-second poll cycle.
+
+        No retries — if the charger doesn't respond within 3 seconds the next poll
+        is only 2 seconds away anyway, so retrying would cause polls to stack.
+        """
+        sock = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.settimeout(3)
+            sock.sendto(request, (self.ip_address, self.port))
+            response, _ = sock.recvfrom(1024)
+            return response
+        except socket.timeout:
+            raise UpdateFailed("Live UDP request timed out")
+        except Exception as err:
+            raise UpdateFailed(f"Live UDP request failed: {err}")
+        finally:
+            if sock:
+                sock.close()

--- a/custom_components/beny_wifi/sensor.py
+++ b/custom_components/beny_wifi/sensor.py
@@ -37,6 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up sensor platform."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    live_coordinator = hass.data[DOMAIN][config_entry.entry_id]["live_coordinator"]
     serial = get_config_parameter(config_entry, SECTION_DEVICE, SERIAL)
     device_model = get_config_parameter(config_entry, SECTION_DEVICE, MODEL)
     device_type = get_config_parameter(config_entry, SECTION_DEVICE, CHARGER_TYPE)
@@ -44,51 +45,60 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     sensors = []
 
-    # by default only all 1-phase sensors are included
+    # Sensors are split between two coordinators:
+    #   live_coordinator (5s):  power, current, voltage
+    #   coordinator (main interval): everything else
+    #
+    # Both coordinators produce data dicts; CoordinatorEntity handles
+    # update subscription automatically based on which coordinator is passed.
+
     if device_type == '1P':
         sensors = [
+            # --- Main coordinator sensors (slow-changing) ---
             BenyWifiChargerStateSensor(coordinator, "charger_state", device_model=device_model, serial=serial),
-            BenyWifiPowerSensor(coordinator, "power", device_model=device_model, serial=serial),
-            BenyWifiVoltageSensor(coordinator, "voltage1", device_model=device_model, serial=serial),
-            BenyWifiCurrentSensor(coordinator, "current1", device_model=device_model, serial=serial),
-            BenyWifiCurrentSensor(coordinator, "max_current", device_model=device_model, serial=serial),
             BenyWifiEnergySensor(coordinator, "total_kwh", device_model=device_model, serial=serial),
             BenyWifiTemperatureSensor(coordinator, "temperature", device_model=device_model, serial=serial),
             BenyWifiEnergySensor(coordinator, "maximum_session_consumption", icon="mdi:meter-electric", device_model=device_model, serial=serial),
             BenyWifiTimerSensor(coordinator, "timer_start", icon="mdi:timer-sand-full", device_model=device_model, serial=serial),
             BenyWifiTimerSensor(coordinator, "timer_end", icon="mdi:timer-sand-empty", device_model=device_model, serial=serial),
             BenyWifiSensor(coordinator, "fault_code", icon="mdi:alert-circle-outline", device_model=device_model, serial=serial),
-            BenyWifiLatencySensor(coordinator, "udp_latency", device_model=device_model, serial=serial)
+            BenyWifiLatencySensor(coordinator, "udp_latency", device_model=device_model, serial=serial),
+            # --- Live coordinator sensors (5s) ---
+            BenyWifiPowerSensor(live_coordinator, "power", device_model=device_model, serial=serial),
+            BenyWifiVoltageSensor(live_coordinator, "voltage1", device_model=device_model, serial=serial),
+            BenyWifiCurrentSensor(live_coordinator, "current1", device_model=device_model, serial=serial),
+            BenyWifiCurrentSensor(live_coordinator, "max_current", device_model=device_model, serial=serial),
         ]
 
-    # add all three phases if model supports them
     elif device_type == '3P':
         sensors = [
+            # --- Main coordinator sensors (slow-changing) ---
             BenyWifiChargerStateSensor(coordinator, "charger_state", device_model=device_model, serial=serial),
-            BenyWifiPowerSensor(coordinator, "power", device_model=device_model, serial=serial),
-            BenyWifiVoltageSensor(coordinator, "voltage1", device_model=device_model, serial=serial),
-            BenyWifiVoltageSensor(coordinator, "voltage2", device_model=device_model, serial=serial),
-            BenyWifiVoltageSensor(coordinator, "voltage3", device_model=device_model, serial=serial),
-            BenyWifiCurrentSensor(coordinator, "current1", device_model=device_model, serial=serial),
-            BenyWifiCurrentSensor(coordinator, "current2", device_model=device_model, serial=serial),
-            BenyWifiCurrentSensor(coordinator, "current3", device_model=device_model, serial=serial),
-            BenyWifiCurrentSensor(coordinator, "max_current", device_model=device_model, serial=serial),
             BenyWifiEnergySensor(coordinator, "total_kwh", device_model=device_model, serial=serial),
             BenyWifiTemperatureSensor(coordinator, "temperature", device_model=device_model, serial=serial),
             BenyWifiEnergySensor(coordinator, "maximum_session_consumption", icon="mdi:meter-electric", device_model=device_model, serial=serial),
             BenyWifiTimerSensor(coordinator, "timer_start", icon="mdi:timer-sand-full", device_model=device_model, serial=serial),
             BenyWifiTimerSensor(coordinator, "timer_end", icon="mdi:timer-sand-empty", device_model=device_model, serial=serial),
             BenyWifiSensor(coordinator, "fault_code", icon="mdi:alert-circle-outline", device_model=device_model, serial=serial),
-            BenyWifiLatencySensor(coordinator, "udp_latency", device_model=device_model, serial=serial)
+            BenyWifiLatencySensor(coordinator, "udp_latency", device_model=device_model, serial=serial),
+            # --- Live coordinator sensors (5s) ---
+            BenyWifiPowerSensor(live_coordinator, "power", device_model=device_model, serial=serial),
+            BenyWifiVoltageSensor(live_coordinator, "voltage1", device_model=device_model, serial=serial),
+            BenyWifiVoltageSensor(live_coordinator, "voltage2", device_model=device_model, serial=serial),
+            BenyWifiVoltageSensor(live_coordinator, "voltage3", device_model=device_model, serial=serial),
+            BenyWifiCurrentSensor(live_coordinator, "current1", device_model=device_model, serial=serial),
+            BenyWifiCurrentSensor(live_coordinator, "current2", device_model=device_model, serial=serial),
+            BenyWifiCurrentSensor(live_coordinator, "current3", device_model=device_model, serial=serial),
+            BenyWifiCurrentSensor(live_coordinator, "max_current", device_model=device_model, serial=serial),
         ]
 
-    # TODO: DLB
+    # DLB power sensors always go on the live coordinator
     if dlb:
         sensors.extend([
-            BenyWifiPowerSensor(coordinator, "grid_power", icon="mdi:transmission-tower", device_model=device_model, serial=serial),
-            BenyWifiPowerSensor(coordinator, "solar_power", icon="mdi:solar-power-variant", device_model=device_model, serial=serial),
-            BenyWifiPowerSensor(coordinator, "ev_power", icon="mdi:car-electric", device_model=device_model, serial=serial),
-            BenyWifiPowerSensor(coordinator, "house_power", icon="mdi:home-lightning-bolt", device_model=device_model, serial=serial),
+            BenyWifiPowerSensor(live_coordinator, "grid_power", icon="mdi:transmission-tower", device_model=device_model, serial=serial),
+            BenyWifiPowerSensor(live_coordinator, "solar_power", icon="mdi:solar-power-variant", device_model=device_model, serial=serial),
+            BenyWifiPowerSensor(live_coordinator, "ev_power", icon="mdi:car-electric", device_model=device_model, serial=serial),
+            BenyWifiPowerSensor(live_coordinator, "house_power", icon="mdi:home-lightning-bolt", device_model=device_model, serial=serial),
         ])
 
     async_add_entities(sensors)
@@ -170,7 +180,7 @@ class BenyWifiPowerSensor(BenyWifiSensor):
     def __init__(self, coordinator, key, device_model=None, serial=None, icon="mdi:ev-plug-type2"):
         """Initialize sensor."""
         super().__init__(coordinator, key, serial=serial, device_model=device_model, icon=icon)
-            
+
     @property
     def available(self) -> bool:
         """Return False once a DLB field has been None for STALE_THRESHOLD consecutive polls.
@@ -179,6 +189,10 @@ class BenyWifiPowerSensor(BenyWifiSensor):
         which already handles device-unreachable via last_update_success.
         For DLB fields, also checks the per-field stale counter so each can go
         unavailable independently of the overall coordinator state.
+
+        BenyWifiLiveCoordinator exposes is_field_stale() by delegating to the main
+        coordinator's stale-count dict, so this check works for sensors on either
+        coordinator.
         """
         if self.key in ("grid_power", "solar_power", "ev_power", "house_power"):
             return super().available and not self.coordinator.is_field_stale(self.key)


### PR DESCRIPTION
This PR introduces a second "live" coordinator that polls fast-changing sensor data (power, current, voltage, DLB power) at 5-second intervals, while keeping the main coordinator responsible for slow-changing data (charger state, energy totals, temperature, timers, faults, DLB config) at the user-configured scan interval.

It also fixes two related reliability issues that emerged from running two coordinators against a single UDP endpoint:

1. **Simultaneous UDP requests causing brief "unavailable" state** — when both coordinators fired at the same time, the charger received two back-to-back requests and responses were mismatched (wrong checksum → `UpdateFailed` → entities briefly went unavailable)
2. **Transient UDP failures producing "unavailable" flashes** — a single failed live poll evicted all live field values from the coordinator's data dict, causing sensors to report unavailable for one cycle even though the device was perfectly reachable

---

## Changes Made

### `coordinator.py`

#### New: `BenyWifiLiveCoordinator`

A second `DataUpdateCoordinator` subclass is introduced. It polls at a fixed `LIVE_POLL_INTERVAL = 5` seconds and is responsible exclusively for:

- Power and current readings (`power`, `current1`–`current3`, `max_current`)
- Voltage readings (`voltage1`–`voltage3`)
- DLB power readings (`grid_power`, `solar_power`, `ev_power`, `house_power`) when DLB is enabled

This separates fast-changing live data from the slower main poll without requiring any changes to the charger communication protocol.

#### New: Shared `asyncio.Lock` for collision avoidance

`BenyWifiUpdateCoordinator` now creates a shared `asyncio.Lock` on init:

```python
self._udp_lock: asyncio.Lock = asyncio.Lock()
```

Both coordinators must hold this lock before sending any UDP request. The live coordinator receives a reference to it via `self._main._udp_lock`. This ensures the two coordinators never occupy the UDP socket simultaneously.

```python
# Main coordinator — _async_update_data
async with self._udp_lock:
    return await self._fetch_data()

# Live coordinator — _async_update_data
async with self._main._udp_lock:
    # ... values packet fetch ...
    # ... DLB packet fetch ...
```

All action methods on the main coordinator (`async_toggle_charging`, `async_set_max_current`, `async_set_dlb_config`, `async_set_timer`, `async_set_schedule`, `async_reset_timer`, `async_request_weekly_schedule`, `async_set_max_monthly_consumption`, `async_set_max_session_consumption`) are also wrapped in `async with self._udp_lock` so user-triggered commands cannot collide with either scheduled poll.

#### New: 3-poll value cache on `BenyWifiLiveCoordinator`

A per-field cache prevents transient UDP failures from propagating to the UI as unavailable flashes:

```python
self._cached_data: dict[str, Any] = {}   # last known valid value per field
self._miss_counts: dict[str, int] = {}   # consecutive missed polls per field
```

Two helpers manage the cache:

```python
def _record_hit(self, field: str, value: Any) -> None:
    """Store a freshly received value and reset its miss counter."""

def _record_miss(self, field: str) -> None:
    """Increment miss counter; evict cache entry once threshold is reached."""
```

Each poll cycle, `_async_update_data` merges fresh device data with the cache:

- **Fresh value received** → cache updated, value included in result, miss counter reset
- **No fresh value, cached value exists** → miss counter incremented, cached value served until `_LIVE_CACHE_MISS_THRESHOLD` (3) consecutive misses, after which the entry is evicted and the sensor honestly becomes unavailable
- **No fresh value, no cache** → field omitted from result

```python
_LIVE_CACHE_MISS_THRESHOLD = 3  # 3 polls × 5s = 15 seconds of tolerance
```

`_async_update_data` never raises `UpdateFailed` directly, so `CoordinatorEntity.available` remains `True` through transient hiccups as long as a cached value exists.

#### New: `_LIVE_CACHE_MISS_THRESHOLD` constant

```python
# Number of consecutive failed live polls before a field's cached value is
# evicted and the sensor falls back to unavailable.
# 3 polls = 15 seconds of tolerance for transient UDP failures.
_LIVE_CACHE_MISS_THRESHOLD = 3
```

---

### `__init__.py`

Both coordinators are instantiated during entry setup and stored in `hass.data` so all platforms can access whichever coordinator owns their sensors:

```python
coordinator = BenyWifiUpdateCoordinator(hass, entry, ip_address, port, scan_interval)
await coordinator.async_config_entry_first_refresh()

live_coordinator = BenyWifiLiveCoordinator(hass, entry, ip_address, port, coordinator)
try:
    await live_coordinator.async_config_entry_first_refresh()
except Exception as ex:
    # Non-fatal: live data will catch up on the next poll cycle.
    _LOGGER.warning(f"Live coordinator first refresh failed (non-fatal): {ex}")

hass.data[DOMAIN][entry.entry_id] = {
    "coordinator": coordinator,
    "live_coordinator": live_coordinator,
}
```

The live coordinator's first refresh failure is treated as non-fatal — the integration continues to load and live data will populate on the next 5-second cycle. The main coordinator's first refresh failure remains fatal (raises `ConfigEntryNotReady`) since it owns device availability.

---

### `sensor.py`

Sensors are split between the two coordinators based on how frequently their underlying data changes. Each sensor receives the appropriate coordinator in its constructor; `CoordinatorEntity` handles update subscription automatically.

```python
# --- Main coordinator sensors (slow-changing) ---
BenyWifiChargerStateSensor(coordinator, "charger_state", ...)
BenyWifiEnergySensor(coordinator, "total_kwh", ...)
BenyWifiTemperatureSensor(coordinator, "temperature", ...)
BenyWifiEnergySensor(coordinator, "maximum_session_consumption", ...)
BenyWifiTimerSensor(coordinator, "timer_start", ...)
BenyWifiTimerSensor(coordinator, "timer_end", ...)
BenyWifiSensor(coordinator, "fault_code", ...)
BenyWifiLatencySensor(coordinator, "udp_latency", ...)

# --- Live coordinator sensors (5s) ---
BenyWifiPowerSensor(live_coordinator, "power", ...)
BenyWifiVoltageSensor(live_coordinator, "voltage1", ...)
BenyWifiCurrentSensor(live_coordinator, "current1", ...)
BenyWifiCurrentSensor(live_coordinator, "max_current", ...)
```

DLB power sensors (`grid_power`, `solar_power`, `ev_power`, `house_power`) always go on the live coordinator regardless of charger phase type.

`BenyWifiPowerSensor.available` is extended to check the per-field stale counter for DLB fields. `BenyWifiLiveCoordinator` exposes `is_field_stale()` by delegating to the main coordinator's stale-count dict, so the check works correctly for sensors on either coordinator:

```python
@property
def available(self) -> bool:
    if self.key in ("grid_power", "solar_power", "ev_power", "house_power"):
        return super().available and not self.coordinator.is_field_stale(self.key)
    return super().available
```

---

## Architecture Summary

```
BenyWifiUpdateCoordinator   (user scan_interval, default 10s)
├── owns: _udp_lock (shared with live coordinator)
├── owns: _dlb_config cache, _stale_counts
└── fetches: charger state, energy, temperature, timers, faults, DLB config

BenyWifiLiveCoordinator     (fixed 5s interval)
├── holds ref: _main → BenyWifiUpdateCoordinator
├── acquires: _main._udp_lock before every UDP send
├── owns: _cached_data, _miss_counts (3-poll value cache)
└── fetches: power, current, voltage, DLB power
```

When both coordinators are scheduled to fire at the same time, the live coordinator acquires the lock and completes its fast poll first; the main coordinator then runs immediately after. Alternatively, if the main coordinator fires first, the live coordinator waits at the lock boundary — typically less than 500 ms — and proceeds once the main poll finishes. In either case there is no concurrent UDP traffic and no mismatched response.

---

## Implementation Notes

- The lock is an `asyncio.Lock`, so waiting at the boundary is non-blocking — the HA event loop continues processing other work while one coordinator waits for the other.
- The live coordinator uses a 3-second UDP timeout with no retries (vs. the main coordinator's 8-second timeout with 2 retries). This ensures each live poll completes well within the 5-second interval even under adverse conditions.
- The 3-poll cache threshold (15 seconds) is deliberately shorter than the existing DLB stale threshold (~3 minutes). The cache is a short-term buffer for transient failures; the stale threshold handles genuinely absent DLB hardware.
- No changes to the charger communication protocol, entity unique IDs, config entry structure, or service interfaces.

---

## Testing

- **Hardware**: Beny Charger BCP-A2N-L (firmware 1.28) with Solar DLB module
- **Verified**:
  - Live sensors (power, current, voltage, DLB power) update every 5 seconds
  - Main sensors (state, energy, temperature, timers, faults) update at the configured scan interval
  - No "unavailable" flashes observed during extended monitoring with both coordinators running
  - Simulated UDP timeout on a live poll: sensors retained last known values for 15 seconds before going unavailable
  - User-triggered commands (start/stop charging, set max current, set DLB config) no longer collide with scheduled polls
  - Integration loads cleanly on HA restart; live coordinator first-refresh failure is handled gracefully

---

## Breaking Changes

None. Sensor entity IDs, unique IDs, and state semantics are unchanged. Existing automations and dashboards referencing these sensors are unaffected. The only observable difference is that live sensors now update at 5-second intervals rather than the main scan interval.

---

## Checklist

- [x] Root cause identified for both collision and unavailable-flash issues
- [x] `coordinator.py`: `BenyWifiLiveCoordinator` introduced with 5-second poll interval
- [x] `coordinator.py`: shared `asyncio.Lock` prevents simultaneous UDP requests
- [x] `coordinator.py`: all action methods wrapped in `async with self._udp_lock`
- [x] `coordinator.py`: 3-poll value cache prevents transient failures from flashing unavailable
- [x] `__init__.py`: both coordinators instantiated and stored in `hass.data`
- [x] `__init__.py`: live coordinator first-refresh failure treated as non-fatal
- [x] `sensor.py`: sensors split between coordinators by data change rate
- [x] `sensor.py`: DLB power sensors assigned to live coordinator
- [x] `sensor.py`: `BenyWifiPowerSensor.available` checks per-field stale counter via `is_field_stale()`
- [x] All modified files pass Python syntax check